### PR TITLE
Gha updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,5 @@
 name: Deploy New Version
 
-concurrency: dummy-h-periodic-deploy
-
 on:
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,7 +1,5 @@
 name: Redeploy Current Version
 
-concurrency: dummy-h-periodic-redeploy
-
 on:
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -39,7 +39,7 @@ jobs:
         repository: hypothesis/dummy-deploy
         ssh-key: ${{ secrets.DEPLOYMENT_KEY }}
     - name: install boto3
-      run: pip install boto3
+      run: pip install boto3 pyaml
     - name: Redeploy Current Version
       run: |
-        ./bin/jenkins
+        ./bin/init.sh

--- a/.github/workflows/sync-env.yml
+++ b/.github/workflows/sync-env.yml
@@ -1,7 +1,5 @@
 name: Synchronize AWS Environment
 
-concurrency: dummy-h-periodic-sync-env
-
 on:
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/sync-env.yml
+++ b/.github/workflows/sync-env.yml
@@ -39,7 +39,7 @@ jobs:
         repository: hypothesis/dummy-deploy
         ssh-key: ${{ secrets.DEPLOYMENT_KEY }}
     - name: install boto3
-      run: pip install boto3
+      run: pip install boto3 pyaml
     - name: Synchronize AWS Environment
       run: |
-        ./bin/jenkins
+        ./bin/init.sh


### PR DESCRIPTION
Basic updates to the manually triggered workflows.

1. Move workflows over to use the new init.sh deployment script
2. Removed `concurrency` lock as we might need to run multiples at the same time.